### PR TITLE
previousData prop on QueryResult as of 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@apollo/client": "^3.1.3",
+    "@apollo/client": "3.3.7",
     "@reasonml-community/graphql-ppx": "^1.0.0",
     "bs-platform": "8.4.2",
     "graphql": "^14.0.0",
@@ -31,7 +31,7 @@
     "subscriptions-transport-ws": "^0.9.17"
   },
   "peerDependencies": {
-    "@apollo/client": "^3.0.0",
+    "@apollo/client": "^3.3.0",
     "@reasonml-community/graphql-ppx": "^1.0.0",
     "bs-platform": "^8.2.0",
     "reason-react": "^0.8.0 || ^0.9.0"

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.res
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.res
@@ -227,6 +227,7 @@ module QueryResult = {
     // export interface QueryResult<TData = any, TVariables = OperationVariables> extends ObservableQueryFields<TData, TVariables> {
     //     client: ApolloClient<any>;
     //     data: TData | undefined;
+    //     previousData?: TData;
     //     error?: ApolloError;
     //     loading: boolean;
     //     networkStatus: NetworkStatus;
@@ -236,6 +237,7 @@ module QueryResult = {
       called: bool,
       client: ApolloClient.t,
       data: option<'jsData>,
+      previousData: option<'jsData>,
       error: option<ApolloError.Js_.t>,
       loading: bool,
       networkStatus: NetworkStatus.Js_.t,
@@ -307,6 +309,7 @@ module QueryResult = {
     called: bool,
     client: ApolloClient.t,
     data: option<'data>,
+    previousData: option<Types.parseResult<'data>>,
     error: option<ApolloError.t>,
     loading: bool,
     networkStatus: NetworkStatus.t,
@@ -361,6 +364,9 @@ module QueryResult = {
       ~apolloError=?js.error->Belt.Option.map(ApolloError.fromJs),
       safeParse,
     )
+
+    let previousData = js.previousData->Belt.Option.map(safeParse)
+
     let fetchMore = (
       ~context=?,
       ~mapJsVariables=Utils.identity,
@@ -501,6 +507,7 @@ module QueryResult = {
       called: js.called,
       client: js.client,
       data: data,
+      previousData: previousData,
       error: error,
       loading: js.loading,
       networkStatus: js.networkStatus->NetworkStatus.fromJs,


### PR DESCRIPTION
- Resolves #83 
- Bumps minimum `@apollo/client` dependency to 3.3.0

`previousData` has a type of `option<result<'data, parseResult>>`. We're able to avoid the result on the normal `data` property by returning `None` on data and elevating a parse error to the `error` property of `QueryResult.t`, however I thought it would be confusing to do the same for `previousData`