### PR TITLE
Add subscribe method to ApolloClient.t

### DIFF
--- a/EXAMPLES/package.json
+++ b/EXAMPLES/package.json
@@ -19,7 +19,7 @@
     "webpack-dev-server": "3.11.0"
   },
   "dependencies": {
-    "@apollo/client": "3.2.4",
+    "@apollo/client": "3.3.7",
     "@ryyppy/rescript-promise": "0.0.2",
     "graphql": "15.3.0",
     "react": "16.13.1",

--- a/src/@apollo/client/ApolloClient__Client.res
+++ b/src/@apollo/client/ApolloClient__Client.res
@@ -23,7 +23,7 @@ let createHttpLink = ApolloClient__Link_Http_CreateHttpLink.createHttpLink
 // export { HttpLink } from './link/http/HttpLink.js';
 module HttpLink = ApolloClient__Link_Http_HttpLink
 // export { ApolloClient } from './ApolloClient.js';
-module ApolloClient = ApolloClient__ApolloClient
+module ApolloClient = ApolloClient__Core_ApolloClient
 // export { ApolloCache } from './cache/core/cache.js';
 module ApolloCache = ApolloClient__Cache_Core_Cache.ApolloCache
 // export { Cache } from './cache/core/types/Cache.js';

--- a/src/@apollo/client/core/ApolloClient__Core.res
+++ b/src/@apollo/client/core/ApolloClient__Core.res
@@ -1,3 +1,4 @@
+module ApolloClient = ApolloClient__Core_ApolloClient
 module LocalState = ApolloClient__Core_LocalState
 module NetworkStatus = ApolloClient__Core_NetworkStatus.NetworkStatus
 module ObservableQuery = ApolloClient__Core_ObservableQuery

--- a/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
+++ b/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
@@ -354,6 +354,12 @@ module Js_ = {
   // setLink(newLink: ApolloLink): void;
   @bs.send external setLink: (t, ApolloLink.Js_.t) => unit = "setLink"
 
+  // subscribe<T = any, TVariables = OperationVariables>(options: SubscriptionOptions<TVariables>): Observable<FetchResult<T>>;
+
+  @bs.send
+  external subscribe: (t, SubscriptionOptions.Js_.t) => Observable.Js_.t<FetchResult.Js_.t> =
+    "subscribe"
+
   // <T = any, TVariables = OperationVariables>(options: WatchQueryOptions<TVariables>): ObservableQuery<T, TVariables>;
   @bs.send
   external watchQuery: (

--- a/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.res
+++ b/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.res
@@ -270,6 +270,46 @@ module SubscribeToMoreOptions = {
   }
 }
 
+module SubscriptionOptions = {
+  module Js_ = {
+    // export interface SubscriptionOptions<TVariables = OperationVariables, TData = any> {
+    //     query: DocumentNode | TypedDocumentNode<TData, TVariables>;
+    //     variables?: TVariables;
+    //     fetchPolicy?: FetchPolicy;
+    //     errorPolicy?: ErrorPolicy;
+    //     context?: Record<string, any>;
+    // }
+    type t<'jsVariables> = {
+      query: Graphql.documentNode,
+      // We don't allow optional variables because it's not typesafe
+      variables: 'jsVariables,
+      fetchPolicy: option<FetchPolicy.Js_.t>,
+      errorPolicy: option<ErrorPolicy.Js_.t>,
+      context: option<Js.Json.t>,
+    }
+  }
+
+  type t<'variables> = {
+    query: Graphql.documentNode,
+    variables: 'variables,
+    fetchPolicy: option<FetchPolicy.t>,
+    errorPolicy: option<ErrorPolicy.t>,
+    context: option<Js.Json.t>,
+  }
+
+  let toJs: (
+    t<'variables>,
+    ~mapJsVariables: 'jsVariables => 'jsVariables,
+    ~serializeVariables: 'varibles => 'jsVariables,
+  ) => Js_.t<'jsVariables> = (t, ~mapJsVariables, ~serializeVariables) => {
+    query: t.query,
+    variables: t.variables->serializeVariables->mapJsVariables,
+    fetchPolicy: t.fetchPolicy->Belt.Option.map(FetchPolicy.toJs),
+    errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    context: t.context,
+  }
+}
+
 module MutationUpdaterFn = {
   module Js_ = {
     type t<'jsData> = (. ApolloCache.t<Js.Json.t>, FetchResult.Js_.t<'jsData>) => unit // Non-Js_ cache is correct here

--- a/src/@apollo/client/link/core/ApolloClient__Link_Core_ApolloLink.res
+++ b/src/@apollo/client/link/core/ApolloClient__Link_Core_ApolloLink.res
@@ -32,8 +32,10 @@ module Js_ = {
     external split: (~test: Operation.Js_.t => bool, ~whenTrue: t, ~whenFalse: t) => t = "split"
     // static execute(link: ApolloLink, operation: GraphQLRequest): Observable<FetchResult>;
     @bs.module("@apollo/client") @bs.scope("ApolloLink")
-    external execute: (t, GraphQLRequest.t) => Observable.t<FetchResult.Js_.t<Js.Json.t>> =
-      "execute"
+    external execute: (
+      t,
+      GraphQLRequest.t,
+    ) => Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t> = "execute"
     // static concat(first: ApolloLink | RequestHandler, second: ApolloLink | RequestHandler): ApolloLink;
     @bs.module("@apollo/client") @bs.scope("ApolloLink")
     external concat: (t, t) => t = "concat"

--- a/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.res
+++ b/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.res
@@ -158,11 +158,11 @@ module FetchResult = {
 module NextLink = {
   module Js_ = {
     // export declare type NextLink = (operation: Operation) => Observable<FetchResult>;
-    type t = Operation.Js_.t => Observable.t<FetchResult.Js_.t<Js.Json.t>>
+    type t = Operation.Js_.t => Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>
   }
 
   // These are intentionally Js_.t because we can't know what to parse
-  type t = Operation.t => Observable.t<FetchResult.Js_.t<Js.Json.t>>
+  type t = Operation.t => Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>
 }
 
 module RequestHandler = {
@@ -171,11 +171,14 @@ module RequestHandler = {
     type t = (
       . Operation.Js_.t,
       NextLink.Js_.t,
-    ) => Js.Null.t<Observable.t<FetchResult.Js_.t<Js.Json.t>>>
+    ) => Js.Null.t<Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>>
   }
 
   // These are intentionally Js_.t because we can't know what to parse
-  type t = (Operation.Js_.t, NextLink.Js_.t) => option<Observable.t<FetchResult.Js_.t<Js.Json.t>>>
+  type t = (
+    Operation.Js_.t,
+    NextLink.Js_.t,
+  ) => option<Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>>
 
   let toJs: t => Js_.t = (t, . operation, forward) => t(operation, forward)->Js.Null.fromOption
 }

--- a/src/@apollo/client/link/error/ApolloClient__Link_Error.res
+++ b/src/@apollo/client/link/error/ApolloClient__Link_Error.res
@@ -101,17 +101,17 @@ module ErrorHandler = {
   //     (error: ErrorResponse): Observable<FetchResult> | void;
   // }
   module Js_ = {
-    type t = ErrorResponse.Js_.t => option<Observable.Js_.t<FetchResult.Js_.t<Js.Json.t>>>
+    type t = ErrorResponse.Js_.t => option<Observable.Js_.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>>
   }
 
-  type t = ErrorResponse.t => option<Observable.Js_.t<FetchResult.Js_.t<Js.Json.t>>>
+  type t = ErrorResponse.t => option<Observable.Js_.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>>
 }
 
 module Js_ = {
   // export declare function onError(errorHandler: ErrorHandler): ApolloLink;
   @bs.module("@apollo/client/link/error")
   external onError: (
-    ErrorResponse.Js_.t => option<Observable.Js_.t<FetchResult.Js_.t<Js.Json.t>>>
+    ErrorResponse.Js_.t => option<Observable.Js_.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>>
   ) => ApolloLink.Js_.t = "onError"
 }
 

--- a/src/@apollo/client/react/context/ApolloClient__React_Context_ApolloProvider.res
+++ b/src/@apollo/client/react/context/ApolloClient__React_Context_ApolloProvider.res
@@ -1,4 +1,4 @@
-module ApolloClient = ApolloClient__ApolloClient
+module ApolloClient = ApolloClient__Core_ApolloClient
 
 // export interface ApolloProviderProps<TCache> {
 //     client: ApolloClient<TCache>;

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseApolloClient.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseApolloClient.res
@@ -1,4 +1,4 @@
-module ApolloClient = ApolloClient__ApolloClient
+module ApolloClient = ApolloClient__Core_ApolloClient
 
 @bs.module("@apollo/client")
 external useApolloClient: unit => ApolloClient.t = "useApolloClient"

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.res
@@ -1,4 +1,4 @@
-module ApolloClient = ApolloClient__ApolloClient
+module ApolloClient = ApolloClient__Core_ApolloClient
 module ApolloError = ApolloClient__Errors_ApolloError
 module ErrorPolicy = ApolloClient__Core_WatchQueryOptions.ErrorPolicy
 module Graphql = ApolloClient__Graphql

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseMutation.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseMutation.res
@@ -1,4 +1,4 @@
-module ApolloClient = ApolloClient__ApolloClient
+module ApolloClient = ApolloClient__Core_ApolloClient
 module ApolloError = ApolloClient__Errors_ApolloError
 module ErrorPolicy = ApolloClient__Core_WatchQueryOptions.ErrorPolicy
 module FetchPolicy__noCacheExtracted = ApolloClient__Core_WatchQueryOptions.FetchPolicy__noCacheExtracted

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.res
@@ -1,4 +1,4 @@
-module ApolloClient = ApolloClient__ApolloClient
+module ApolloClient = ApolloClient__Core_ApolloClient
 module ApolloError = ApolloClient__Errors_ApolloError
 module ErrorPolicy = ApolloClient__Core_WatchQueryOptions.ErrorPolicy
 module Graphql = ApolloClient__Graphql

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.res
@@ -1,4 +1,4 @@
-module ApolloClient = ApolloClient__ApolloClient
+module ApolloClient = ApolloClient__Core_ApolloClient
 module ApolloError = ApolloClient__Errors_ApolloError
 module BaseSubscriptionOptions = ApolloClient__React_Types.BaseSubscriptionOptions
 module FetchPolicy = ApolloClient__Core_WatchQueryOptions.FetchPolicy

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.res
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.res
@@ -1,4 +1,4 @@
-module ApolloClient = ApolloClient__ApolloClient
+module ApolloClient = ApolloClient__Core_ApolloClient
 module ApolloError = ApolloClient__Errors_ApolloError
 module ApolloQueryResult = ApolloClient__Core_Types.ApolloQueryResult
 module ErrorPolicy = ApolloClient__Core_WatchQueryOptions.ErrorPolicy

--- a/src/ApolloClient__Utils.res
+++ b/src/ApolloClient__Utils.res
@@ -4,28 +4,7 @@ module Types = ApolloClient__Types
 
 @bs.new external makeError: string => Js.Exn.t = "Error"
 
-@unboxed
-type rec any = Any('a): any
-
-let ensureError: any => Js.Exn.t = %bs.raw(`
-  function (unknown) {
-    if (unknown instanceof Error) {
-      return unknown;
-    } else {
-      unknown = unknown || {};
-      const message = unknown.message;
-      const errorMessage = unknown.errorMessage;
-      const keys = Object.keys(unknown);
-      const error = new Error(message || errorMessage || "[Non-error exception with keys: " + keys.join(", ") + "]");
-
-      keys.forEach(function(key) {
-        error[key] = unknown[key];
-      });
-
-      return error;
-    }
-  }
-  `)
+let ensureError = ApolloError.ensureError
 
 external asJson: 'any => Js.Json.t = "%identity"
 

--- a/src/ReasonMLCommunity__ApolloClient.res
+++ b/src/ReasonMLCommunity__ApolloClient.res
@@ -1,11 +1,11 @@
 // Creating a client
-type t = ApolloClient__ApolloClient.t
-let make = ApolloClient__ApolloClient.make
+type t = ApolloClient__Core_ApolloClient.t
+let make = ApolloClient__Core_ApolloClient.make
 
-module DefaultWatchQueryOptions = ApolloClient__ApolloClient.DefaultWatchQueryOptions
-module DefaultQueryOptions = ApolloClient__ApolloClient.DefaultQueryOptions
-module DefaultMutateOptions = ApolloClient__ApolloClient.DefaultMutateOptions
-module DefaultOptions = ApolloClient__ApolloClient.DefaultOptions
+module DefaultWatchQueryOptions = ApolloClient__Core_ApolloClient.DefaultWatchQueryOptions
+module DefaultQueryOptions = ApolloClient__Core_ApolloClient.DefaultQueryOptions
+module DefaultMutateOptions = ApolloClient__Core_ApolloClient.DefaultMutateOptions
+module DefaultOptions = ApolloClient__Core_ApolloClient.DefaultOptions
 
 // Fetching data
 module React = {
@@ -110,6 +110,7 @@ module Types = {
   module RequestHandler = ApolloClient__Link_Core_Types.RequestHandler
   module Resolvers = ApolloClient__Core_Types.Resolvers
   module SubscriptionHookOptions = ApolloClient__React_Types.SubscriptionHookOptions
+  module SubscriptionOptions = ApolloClient__Core_WatchQueryOptions.SubscriptionOptions
   module TypePolicies = ApolloClient__Cache_InMemory_Policies.TypePolicies
   module TypePolicy = ApolloClient__Cache_InMemory_Policies.TypePolicy
   module UriFunction = ApolloClient__Link_Http_SelectHttpOptionsAndBody.UriFunction

--- a/src/zen-observable/ApolloClient__ZenObservable.res
+++ b/src/zen-observable/ApolloClient__ZenObservable.res
@@ -76,25 +76,38 @@ module Observable = {
     //     static from<R>(observable: Observable<R> | ZenObservable.ObservableLike<R> | ArrayLike<R>): Observable<R>;
     //     static of<R>(...items: R[]): Observable<R>;
     // }
-    type t<'t>
+    type t<'t, 'error>
 
     // <R>(callback: (value: T) => R): Observable<R>;
-    @bs.send external map: (t<'t>, 't => 'r) => t<'r> = "map"
+    @bs.send external map: (t<'t, 'error>, 't => 'r) => t<'r, 'error> = "map"
 
     // (onNext: (value: T) => void, onError?: (error: any) => void, onComplete?: () => void): ZenObservable.Subscription;
     @bs.send
     external subscribe: (
-      t<'t>,
+      t<'t, 'error>,
       ~onNext: 't => unit,
-      ~onError: Js.Json.t => unit=?,
+      ~onError: 'error => unit=?,
       ~onComplete: unit => unit=?,
       unit,
-    ) => Subscription.t = "subscribe"
+    ) => Subscription.Js_.t = "subscribe"
 
     // (observer: ZenObservable.Observer<T>): ZenObservable.Subscription;
     @bs.send
-    external subscribeWithObserver: (t<'t>, Observer.t<'t>) => Subscription.t = "subscribe"
+    external subscribeWithObserver: (t<'t, 'error>, Observer.t<'t>) => Subscription.Js_.t =
+      "subscribe"
   }
 
-  include Js_
+  type t<'t, 'error> = {
+    subscribe: (
+      ~onNext: 't => unit,
+      ~onError: 'error => unit=?,
+      ~onComplete: unit => unit=?,
+      unit,
+    ) => Subscription.t,
+  }
+
+  let fromJs: Js_.t<'t, 'error> => t<'t, 'error> = t => {
+    subscribe: (~onNext, ~onError=?, ~onComplete=?, ()) =>
+      t->Js_.subscribe(~onNext, ~onError?, ~onComplete?, ())->Subscription.fromJs,
+  }
 }


### PR DESCRIPTION
It's always hard to strike the right balance of having accurate types in reason when many of these types are reused in typescript with `any`, like the `Observable` type in `ZenObservable`. I cheated a bit here and chose to just say that observables returned by apollo links always error with `Js.Exn.t`. We may need to revisit this.