### PR TITLE
NextLink types

### DIFF
--- a/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.res
+++ b/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.res
@@ -158,11 +158,11 @@ module FetchResult = {
 module NextLink = {
   module Js_ = {
     // export declare type NextLink = (operation: Operation) => Observable<FetchResult>;
-    type t = Operation.Js_.t => Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>
+    type t = Operation.Js_.t => Observable.Js_.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>
   }
 
   // These are intentionally Js_.t because we can't know what to parse
-  type t = Operation.t => Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>
+  type t = Operation.t => Observable.Js_.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>
 }
 
 module RequestHandler = {

--- a/src/zen-observable/ApolloClient__ZenObservable.res
+++ b/src/zen-observable/ApolloClient__ZenObservable.res
@@ -97,6 +97,7 @@ module Observable = {
       "subscribe"
   }
 
+  // It's important that the rescript-wrapped version statisfy the Js_.t interface since they'll be used internally by Apollo
   type t<'t, 'error> = {
     subscribe: (
       ~onNext: 't => unit,
@@ -106,6 +107,7 @@ module Observable = {
     ) => Subscription.t,
   }
 
+  // This fromJs feels more like some kind of map over multiple callbacks
   let fromJs: Js_.t<'t, 'error> => t<'t, 'error> = t => {
     subscribe: (~onNext, ~onError=?, ~onComplete=?, ()) =>
       t->Js_.subscribe(~onNext, ~onError?, ~onComplete?, ())->Subscription.fromJs,


### PR DESCRIPTION
Need to adjust NextLink types to account for the fact that zen-observable `Js_.t` and `t` types are different now. 