### PR TITLE
Add missing comma from docs

### DIFF
--- a/documentationWebsite/docs/client-configuration.md
+++ b/documentationWebsite/docs/client-configuration.md
@@ -15,7 +15,7 @@ let client = {
     ~cache=Cache.InMemoryCache.make(),
     // I would turn this off in production
     ~connectToDevTools=true,
-    ~uri="https://graphql.org/swapi-graphql",
+    ~uri=_ => "https://graphql.org/swapi-graphql",
     (),
   )
 }

--- a/documentationWebsite/docs/client-configuration.md
+++ b/documentationWebsite/docs/client-configuration.md
@@ -15,7 +15,7 @@ let client = {
     ~cache=Cache.InMemoryCache.make(),
     // I would turn this off in production
     ~connectToDevTools=true,
-    ~uri="https://graphql.org/swapi-graphql"
+    ~uri="https://graphql.org/swapi-graphql",
     (),
   )
 }


### PR DESCRIPTION
This code doesn't actually compile as is, it is looking for a `UriFunction.t`. I'm not sure if this is an error and should be changed to just a string. The docs don't mention any function.
(currently my code has `~uri="somelink"->Obj.magic` and it is working)