### PR TITLE
Fix memoization

### DIFF
--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.res
@@ -88,14 +88,10 @@ let useQuery:
       ),
     )
 
-    Utils.useGuaranteedMemo1(
-      () =>
-        jsQueryResult->QueryResult.fromJs(
-          ~safeParse,
-          ~serialize=Operation.serialize,
-          ~serializeVariables=Operation.serializeVariables,
-        ),
-      jsQueryResult,
+    jsQueryResult->QueryResult.useFromJs(
+      ~safeParse,
+      ~serialize=Operation.serialize,
+      ~serializeVariables=Operation.serializeVariables,
     )
   }
 


### PR DESCRIPTION
It's necessary to put `subscribeToMore` in the dependencies of `useEffect` (the first one that is received on mount doesn't work). This means that it needs to be memoized in sync with the JS value. Because there is a function `fromJS` where it's not possible to add hooks I created `useFromJs`. I also had trouble satisfying the typechecker when passing a function to `useMemo` (I got "This field value has type ... which is less general than ..."). So I brute forced with `Obj.magic` (external types are correct anyway and without `useMemo` it also works).

Let me know what you think. There are some refactoring possibilities.

Oh yeah. `subscribeToMore` returns an `unsubscribe` function which is pretty important, because it needs to be called to clean up the `useEffect` hook.