### PR TITLE
@rescript/react@0.10.1

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -17,5 +17,5 @@
     }
   ],
   "suffix": ".bs.js",
-  "bs-dependencies": ["@reasonml-community/graphql-ppx", "reason-react"]
+  "bs-dependencies": ["@reasonml-community/graphql-ppx", "@rescript/react"]
 }

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "jest": "26.5.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "reason-react": "^0.9.1",
+    "@rescript/react": "^0.10.1",
     "subscriptions-transport-ws": "^0.9.17"
   },
   "peerDependencies": {
     "@apollo/client": "^3.3.0",
     "@reasonml-community/graphql-ppx": "^1.0.0",
     "bs-platform": "^8.2.0 || ^9.0.0",
-    "reason-react": "^0.8.0 || ^0.9.0"
+    "@rescript/react": "^0.10.1"
   }
 }


### PR DESCRIPTION
Looks like having `reason-react` in deps is causing problems when using with `rescript`.

See https://github.com/rescript-lang/rescript-react/issues/6#issuecomment-778343804

This fixed it in a patch for me. Once its updated you would have to update the import in the example.