### PR TITLE
Next (@rescript/react)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+**/__tests__/**
 .bsb.lock
 *.bs.js
 .gitattributes
@@ -15,7 +16,6 @@ EXAMPLES/
 lib/
 node_modules/
 package-lock.json
-README.md
 TODO
 yarn.lock
 yarn-error.log

--- a/EXAMPLES/bsconfig.json
+++ b/EXAMPLES/bsconfig.json
@@ -31,6 +31,6 @@
     "rescript-apollo-client",
     "@reasonml-community/graphql-ppx",
     "@ryyppy/rescript-promise",
-    "reason-react"
+    "@rescript/react"
   ]
 }

--- a/EXAMPLES/package.json
+++ b/EXAMPLES/package.json
@@ -26,7 +26,7 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "reason-promise": "1.1.1",
-    "rescript-apollo-client": "1.1.2",
+    "rescript-apollo-client": "2.0.1",
     "subscriptions-transport-ws": "0.9.16"
   }
 }

--- a/EXAMPLES/package.json
+++ b/EXAMPLES/package.json
@@ -26,7 +26,7 @@
     "react-dom": "16.13.1",
     "reason-promise": "1.1.1",
     "reason-react": "0.9.1",
-    "rescript-apollo-client": "1.1.0",
+    "rescript-apollo-client": "1.1.1",
     "subscriptions-transport-ws": "0.9.16"
   }
 }

--- a/EXAMPLES/package.json
+++ b/EXAMPLES/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@reasonml-community/graphql-ppx": "1.0.0",
-    "bs-platform": "8.2.0",
+    "bs-platform": "9.0.0",
     "graphql-client-example-server": "1.2.0",
     "html-webpack-plugin": "4.3.0",
     "webpack": "4.43.0",
@@ -20,13 +20,13 @@
   },
   "dependencies": {
     "@apollo/client": "3.3.7",
+    "@rescript/react": "0.10.1",
     "@ryyppy/rescript-promise": "0.0.2",
     "graphql": "15.3.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "reason-promise": "1.1.1",
-    "reason-react": "0.9.1",
-    "rescript-apollo-client": "1.1.1",
+    "rescript-apollo-client": "../",
     "subscriptions-transport-ws": "0.9.16"
   }
 }

--- a/EXAMPLES/src/WebpackEntry.res
+++ b/EXAMPLES/src/WebpackEntry.res
@@ -1,1 +1,4 @@
-ReactDOMRe.renderToElementWithId(<App />, "root")
+switch ReactDOM.querySelector("#root") {
+| Some(root) => ReactDOM.render(<App />, root)
+| None => ()
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rescript-apollo-client",
   "description": "ReScript bindings for the Apollo Client ecosystem",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "keywords": [
     "Apollo",
     "BuckleScript",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rescript-apollo-client",
   "description": "ReScript bindings for the Apollo Client ecosystem",
-  "version": "1.1.2",
+  "version": "2.0.1",
   "keywords": [
     "Apollo",
     "BuckleScript",
@@ -35,5 +35,10 @@
     "@reasonml-community/graphql-ppx": "^1.0.0",
     "bs-platform": "^8.2.0 || ^9.0.0",
     "@rescript/react": "^0.10.1"
+  },
+  "peerDependenciesMeta": {
+    "bs-platform": {
+      "optional": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rescript-apollo-client",
   "description": "ReScript bindings for the Apollo Client ecosystem",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "keywords": [
     "Apollo",
     "BuckleScript",


### PR DESCRIPTION
This branch is available via `rescript-apollo-client@next`. The only change is updating the `reason-react` dependency to `@rescript/react`. My plan was to wait for a proper release until any documentation (migration or otherwise) is up for it.